### PR TITLE
add wincertstore to dev.in

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
 -c prod.txt
 black
 pre-commit
+wincertstore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,8 @@ cfgv==3.3.1
     # via pre-commit
 click==8.1.3
     # via black
+colorama==0.4.5
+    # via click
 distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
@@ -47,6 +49,8 @@ typing-extensions==4.3.0
     #   importlib-metadata
 virtualenv==20.16.5
     # via pre-commit
+wincertstore==0.2
+    # via -r requirements/dev.in
 zipp==3.8.1
     # via importlib-metadata
 


### PR DESCRIPTION
Add "wincertstore"  to dev.in so that it works on windows.
Otherwise, it has the following problem:
https://github.com/full-stack-deep-learning/fsdl-text-recognizer-2021-labs/issues/24