### PR TITLE
Removes horizon_net folder from flake8 checks and removes some checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-select = ANN,B,B9,BLK,C,D,E,F,I,S,W
+select = B,B9,BLK,C,D,E,F,I,S,W
   # only check selected error codes
 application-import-names = horizon_net
   # flake8-import-order: which names are first party?
@@ -13,8 +13,13 @@ docstring-style = numpy
   # darglint: which docstring style guide do we use?
 suppress-none-returning = true
   # flake8-annotations: do we allow un-annotated Nones in returns?
+max-line-length = 160
+  # flake8: max line length
 mypy-init-return = true
   # flake8-annotations: do we allow init to have no return annotation?
 per-file-ignores =
   # list of case-by-case ignores, see files for details
-  model/app.py:D100,D103,ANN001,ANN201
+  model/app.py:D100,D103
+exclude =
+  horizon_net/assets/*
+  horizon_net/misc/*


### PR DESCRIPTION
ANN are checks for typehints. Open for suggestions for additional error codes to exclude or horizon net files to exclude, don't want to get bogged down in this.